### PR TITLE
Auto corrected by following Lint Ruby Lint/UnusedBlockArgument

### DIFF
--- a/lib/synvert/core/utils.rb
+++ b/lib/synvert/core/utils.rb
@@ -40,7 +40,7 @@ module Synvert::Core
           ignored_files = []
 
           if Configuration.respect_gitignore
-            Open3.popen3('git check-ignore --stdin') do |stdin, stdout, stderr, wait_thr|
+            Open3.popen3('git check-ignore --stdin') do |stdin, stdout, _stderr, _wait_thr|
               stdin.puts(all_files.join("\n"))
               stdin.close
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/UnusedBlockArgument

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core-ruby/lint_configs/ruby/10814) to configure it on awesomecode.io