### PR TITLE
Add support for custom BUNDLE_GEMFILE lock files

### DIFF
--- a/lib/synvert/core/rewriter/gem_spec.rb
+++ b/lib/synvert/core/rewriter/gem_spec.rb
@@ -26,7 +26,7 @@ module Synvert::Core
     def match?
       return true unless Configuration.strict
 
-      gemfile_lock_path = File.expand_path(File.join(Configuration.root_path, 'Gemfile.lock'))
+      gemfile_lock_path = File.expand_path(File.join(Configuration.root_path, gemfile_lock_name))
 
       # if Gemfile.lock does not exist, just ignore this check
       return true unless File.exist?(gemfile_lock_path)
@@ -34,6 +34,14 @@ module Synvert::Core
       ENV['BUNDLE_GEMFILE'] = Configuration.root_path # make sure bundler reads Gemfile.lock in the correct path
       parser = Bundler::LockfileParser.new(File.read(gemfile_lock_path))
       parser.specs.any? { |spec| Gem::Dependency.new(@name, @version).match?(spec) }
+    end
+
+    private
+
+    def gemfile_lock_name
+      return "#{File.basename(ENV['BUNDLE_GEMFILE'])}.lock" if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+      'Gemfile.lock'
     end
   end
 end

--- a/spec/synvert/core/rewriter/gem_spec_spec.rb
+++ b/spec/synvert/core/rewriter/gem_spec_spec.rb
@@ -15,46 +15,52 @@ module Synvert::Core
           rake (10.1.1)
           slop (3.4.7)
     EOS
-    let(:lock_path) { File.absolute_path('./Gemfile.lock') }
+    let(:gemfile_lock_path) { File.absolute_path('./Gemfile.lock') }
+    let(:gemfile_path) { File.absolute_path('./Gemfile') }
 
     before do
-      Configuration.root_path = File.dirname(lock_path)
+      Configuration.root_path = File.dirname(gemfile_lock_path)
+      @original_bundle_gemfile = ENV['BUNDLE_GEMFILE']
+      ENV['BUNDLE_GEMFILE'] = gemfile_path
     end
 
     after do
       Configuration.root_path = nil
+      ENV['BUNDLE_GEMFILE'] = @original_bundle_gemfile
     end
 
-    it 'returns true if version in Gemfile.lock is greater than definition' do
-      expect(File).to receive(:exist?).with(lock_path).and_return(true)
-      expect(File).to receive(:read).with(lock_path).and_return(gemfile_lock_content)
-      gem_spec = Rewriter::GemSpec.new('ast', '~> 1.1')
-      expect(gem_spec).to be_match
+    def mock_gemfile_and_lock(gemfile_path, gemfile_lock_path, exists: true)
+      if gemfile_path
+        expect(File).to receive(:exist?).with(gemfile_path).and_return(true)
+      else
+        expect(File).to receive(:exist?).with(nil).and_return(false)
+      end
+      expect(File).to receive(:exist?).with(gemfile_lock_path).and_return(exists)
+      expect(File).to receive(:read).with(gemfile_lock_path).and_return(gemfile_lock_content) if exists
     end
 
-    it 'returns true if version in Gemfile.lock is equal to definition' do
-      expect(File).to receive(:exist?).with(lock_path).and_return(true)
-      expect(File).to receive(:read).with(lock_path).and_return(gemfile_lock_content)
-      gem_spec = Rewriter::GemSpec.new('ast', '1.1.0')
-      expect(gem_spec).to be_match
+    shared_examples 'gem version matching' do |version, expected_match|
+      it "returns #{expected_match} for version #{version}" do
+        mock_gemfile_and_lock(gemfile_path, gemfile_lock_path)
+        gem_spec = Rewriter::GemSpec.new('ast', version)
+        expect(gem_spec).send(expected_match ? :to : :not_to, be_match)
+      end
     end
 
-    it 'returns false if version in Gemfile.lock is less than definition' do
-      expect(File).to receive(:exist?).with(lock_path).and_return(true)
-      expect(File).to receive(:read).with(lock_path).and_return(gemfile_lock_content)
-      gem_spec = Rewriter::GemSpec.new('ast', '> 1.2.0')
-      expect(gem_spec).not_to be_match
+    context 'when checking gem versions' do
+      include_examples 'gem version matching', '~> 1.1', true
+      include_examples 'gem version matching', '1.1.0', true
+      include_examples 'gem version matching', '> 1.2.0', false
     end
 
     it 'returns false if gem does not exist in Gemfile.lock' do
-      expect(File).to receive(:exist?).with(lock_path).and_return(true)
-      expect(File).to receive(:read).with(lock_path).and_return(gemfile_lock_content)
+      mock_gemfile_and_lock(gemfile_path, gemfile_lock_path)
       gem_spec = Rewriter::GemSpec.new('synvert', '1.0.0')
       expect(gem_spec).not_to be_match
     end
 
     it 'returns true if Gemfile.lock does not exist' do
-      expect(File).to receive(:exist?).with(lock_path).and_return(false)
+      mock_gemfile_and_lock(gemfile_path, gemfile_lock_path, exists: false)
       gem_spec = Rewriter::GemSpec.new('ast', '1.1.0')
       expect(gem_spec).to be_match
     end
@@ -64,6 +70,24 @@ module Synvert::Core
       gem_spec = Rewriter::GemSpec.new('synvert', '1.0.0')
       expect(gem_spec).to be_match
       Configuration.strict = true
+    end
+
+    describe 'gemfile lock name behavior' do
+      it 'uses default Gemfile.lock when BUNDLE_GEMFILE is not set' do
+        ENV['BUNDLE_GEMFILE'] = nil
+        mock_gemfile_and_lock(nil, gemfile_lock_path)
+        gem_spec = Rewriter::GemSpec.new('ast', '1.1.0')
+        expect(gem_spec).to be_match
+      end
+
+      it 'uses custom Gemfile lock name when BUNDLE_GEMFILE is set' do
+        custom_gemfile = File.absolute_path('./Gemfile.next')
+        custom_gemfile_lock_path = File.absolute_path('./Gemfile.next.lock')
+        ENV['BUNDLE_GEMFILE'] = custom_gemfile
+        mock_gemfile_and_lock(custom_gemfile, custom_gemfile_lock_path)
+        gem_spec = Rewriter::GemSpec.new('ast', '1.1.0')
+        expect(gem_spec).to be_match
+      end
     end
   end
 end


### PR DESCRIPTION
Yeah, the standard and most Ruby applications use `Gemfile` and `Gemfile.lock`
to track our own dependencies file, however, I'd like to add support for
those apps that does not use `Gemfile` to store their dependencies,
but use a custom name set via `ENV['BUNDLE_GEMFILE']`.

This is useful when you have multiple `Gemfiles` in the same
application, you will have the flexibility to run the `synvert` CLI
command with the different `dependency` context of the application.
